### PR TITLE
Adding support for disabling HTTP Plugins from command line

### DIFF
--- a/explore.go
+++ b/explore.go
@@ -31,6 +31,7 @@ type ExploreServiceCommand struct {
 	JsonDecoder         *json.Decoder                     `kong:"-"`
 	ExploreTimeout      time.Duration                     `short:"x" default:"3s"`
 	DisableExploreStage bool                              `short:"e"`
+	DisableHTTPPlugins  bool                              `short:"w"`
 	ExfiltrateStage     bool                              `short:"x"`
 	Option              map[string]string                 `short:"o"`
 	Debug               bool
@@ -75,7 +76,7 @@ func (cmd *ExploreServiceCommand) Run() error {
 				// Run exfiltrate stage, dump parts or all data to filesystem
 				cmd.RunPlugin(&event, cmd.ExfiltratePlugins)
 			}
-			if event.HasTransport("http") {
+			if event.HasTransport("http") && !cmd.DisableHTTPPlugins {
 				cmd.RunWebPlugin(&event, cmd.HttpPlugins)
 			}
 			event.UpdateFingerprint()


### PR DESCRIPTION
# TLTR
This merge request adds a new feature to disable the Web Plugins to be ran `--disable-http-plugins` or `-w`

# Usecase
When you want to target a specific module, for example elasticsearch, you do not want to run http plugins on this specific port/service. There is no reason to find a `phpinfo.php` on an Elasticsearch server.
Running the HTTP plugins will add a lot more time to the scan and will produce false positive.

For example:
* With HTTP plugins:
`time echo "212.129.152.206:9200"| l9filter transform -i hostport -o l9 | l9tcpid service --max-threads=100 --deep-http | grep elasticsearch | ./l9explorer service --explore-timeout=5s --max-threads=100`

real    0m17.803s
user    0m0.017s
sys     0m0.015s

* Without HTTP Plugins
`time echo "212.129.152.206:9200"| l9filter transform -i hostport -o l9 | l9tcpid service --max-threads=100 --deep-http | grep elasticsearch | ./l9explorer service --explore-timeout=5s --max-threads=100 --disable-http-plugins`

real    0m6.710s
user    0m0.013s
sys     0m0.013s

With this new option, it will allow the user to run specific usecase (for example focus a single service and not inadequate plugins).
