### PR TITLE
Adding support to use json file to use only specific plugins

### DIFF
--- a/plugin_json.go
+++ b/plugin_json.go
@@ -1,0 +1,75 @@
+package l9explore
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+
+	"github.com/LeakIX/l9format"
+)
+
+// GetServicePluginFromString returns the service plugin with the given name
+func GetServicePluginFromString(pluginName string) (plugin l9format.ServicePluginInterface, found bool) {
+	for _, tcpPlugin := range tcpPlugins {
+		if tcpPlugin.GetName() == pluginName {
+			return tcpPlugin, true
+		}
+	}
+	return nil, false
+}
+
+// GetWebPluginFromString returns the web plugin with the given name
+func GetWebPluginFromString(pluginName string) (plugin l9format.WebPluginInterface, found bool) {
+	for _, webPlugin := range webPlugins {
+		if webPlugin.GetName() == pluginName {
+			return webPlugin, true
+		}
+	}
+	return nil, false
+}
+
+const PluginFile = "plugins.json"
+
+type PluginFileStruct struct {
+	Plugins []string `json:"plugins"`
+}
+
+func LoadPluginsFromFile(pluginsJson string) error {
+
+	jsonFile, err := os.Open(pluginsJson)
+	if err != nil {
+		return err
+	}
+
+	defer jsonFile.Close()
+
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+
+	// we initialize our Users array
+	var fileData PluginFileStruct
+
+	err = json.Unmarshal(byteValue, &fileData)
+	if err != nil {
+		return err
+	}
+
+	TcpPlugins = []l9format.ServicePluginInterface{}
+	WebPlugins = []l9format.WebPluginInterface{}
+
+	for _, pluginName := range fileData.Plugins {
+		splug, found := GetServicePluginFromString(pluginName)
+		if found {
+			TcpPlugins = append(TcpPlugins, splug)
+			continue
+		}
+
+		wplug, found := GetWebPluginFromString(pluginName)
+		if found {
+			WebPlugins = append(WebPlugins, wplug)
+			continue
+		}
+
+	}
+
+	return nil
+}

--- a/plugin_map.go
+++ b/plugin_map.go
@@ -2,18 +2,27 @@ package l9explore
 
 import (
 	"github.com/LeakIX/l9format"
-	// Import your plugins here
+	// Import your plugins here"
 	"github.com/LeakIX/l9plugins"
 	l9_nuclei_plugin "github.com/gboddin/l9-nuclei-plugin"
 )
 
+var tcpPlugins = l9plugins.GetTcpPlugins()
+var webPlugins = l9plugins.GetWebPlugins()
+
 var TcpPlugins []l9format.ServicePluginInterface
 var WebPlugins []l9format.WebPluginInterface
 
-func LoadL9ExplorePlugins() {
-	TcpPlugins = append(TcpPlugins, l9plugins.GetTcpPlugins()...)
-	WebPlugins = append(WebPlugins, l9plugins.GetWebPlugins()...)
+func LoadL9ExplorePlugins(pluginsJson string) {
+
+	err := LoadPluginsFromFile(pluginsJson)
+	if err == nil {
+		// Successfully loaded plugin file, so we can now process the plugins
+		return
+	}
+
+	TcpPlugins = append(TcpPlugins, tcpPlugins...)
+	WebPlugins = append(WebPlugins, webPlugins...)
 	// Add your plugins here
 	TcpPlugins = append(TcpPlugins, l9_nuclei_plugin.NucleiPlugin{})
 }
-

--- a/plugins.json
+++ b/plugins.json
@@ -1,0 +1,25 @@
+{
+  "plugins": [
+    "CouchDbOpenPlugin",
+    "ElasticSearchExplorePlugin",
+    "ElasticSearchOpenPlugin",
+    "MongoSchemaPlugin",
+    "MongoOpenPlugin",
+    "SSHOpenPlugin",
+    "DotDsStoreOpenPlugin",
+    "NucleiPlugin",
+    "MysqlOpenPlugin",
+    "MysqlExplorePlugin",
+    "RedisOpenPlugin",
+    "KafkaOpenPlugin",
+    "ApacheStatusHttpPlugin",
+    "ConfigJsonHttp",
+    "DotEnvConfigPlugin",
+    "GitConfigPlugin",
+    "IdxConfigPlugin",
+    "LaravelTelescopeHttpPlugin",
+    "PhpInfoHttpPlugin",
+    "FirebaseHttpPlugin",
+    "WpUserEnumHttp"
+  ]
+}


### PR DESCRIPTION
# TLTR

This merge request adds a new feature to use a Json file to use only specific plugins `--plugins-conf` or `-p`.

# Usecase

If you are scanning for a specific port, you don’t necessarily need to load all the plugins. Therefore, we added a new option to set a specific set of plugins.
The default value is `plugins.json` which is located in the current directory. The format for the file is simple, only the name of the plugins is needed :

```
{
  "plugins": [
    "CouchDbOpenPlugin",
    "ElasticSearchExplorePlugin",
    "ElasticSearchOpenPlugin",
    "MongoSchemaPlugin",
    "MongoOpenPlugin",
    "SSHOpenPlugin",
    "DotDsStoreOpenPlugin",
    "NucleiPlugin",
    "MysqlOpenPlugin",
    "MysqlExplorePlugin",
    "RedisOpenPlugin",
    "KafkaOpenPlugin",
    "ApacheStatusHttpPlugin",
    "ConfigJsonHttp",
    "DotEnvConfigPlugin",
    "GitConfigPlugin",
    "IdxConfigPlugin",
    "LaravelTelescopeHttpPlugin",
    "PhpInfoHttpPlugin",
    "FirebaseHttpPlugin",
    "WpUserEnumHttp"
  ]
}

```